### PR TITLE
fix: use only supported versions of NodeJS 

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [13.x]
+        node-version: [14.x]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [13.x]
+        node-version: [14.x]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ stages:
   - deploy
 
 .build: &build
-  image: node:13
+  image: node:14
   stage: build
   script:
     - yarn audit --groups dependencies

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   node:
-    image: node:13-alpine
+    image: node:14-alpine
     container_name: protego-safe-react
     volumes:
       - ../:/app


### PR DESCRIPTION
Obecnie, do budowania aplikacji PWA używany jest NodeJS który nie jest już wspierany przez NodeJS Foundation.

Więcej informacji na: 
- https://nodejs.org/en/about/releases/